### PR TITLE
Update readme to use php7.2

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,13 +61,13 @@ Here are a few key differences compared to the original Valet:
 > :warning: Valet+ requires macOS and [Homebrew](https://brew.sh/). Before installation, you should make sure that no other programs such as Apache or Nginx are binding to your local machine's port 80.
 
 1. Install or update [Homebrew](https://brew.sh/) to the latest version using `brew update`.
-2. Install PHP 7.1 using Homebrew via `brew install php@7.1`.
+2. Install PHP 7.2 using Homebrew via `brew install php@7.2`.
 3. Install Composer using Homebrew via `brew install composer`.
 4. Install Valet+ with Composer via `composer global require weprovide/valet-plus`.
 5. Add `export PATH="$PATH:$HOME/.composer/vendor/bin"` to `.bash_profile` (for bash) or `.zshrc` (for zsh) depending on your shell (`echo $SHELL`)
 6. Run the `valet fix` command. This will check for common issues preventing Valet+ from installing.
 7. Run the `valet install` command. Optionally add `--with-mariadb` to use MariaDB instead of MySQL This will configure and install Valet+ and DnsMasq, and register Valet's daemon to launch when your system starts.
-8. Once Valet+ is installed, try pinging any `*.test` domain on your terminal using a command such as `ping foobar.test`. If Valet+ is installed correctly you should see this domain responding on `127.0.0.1`. If not you might have to restart your system. Especially when coming from the Dinghy (docker) solution.
+8. Once Valet+ is installed, try pinging any `*.test` domain on your terminal using a command such as `ping -c1 foobar.test`. If Valet+ is installed correctly you should see this domain responding on `127.0.0.1`. If not you might have to restart your system. Especially when coming from the Dinghy (docker) solution.
 
 > :information_source: Valet+ will automatically start its daemon each time your machine boots. There is no need to run `valet start` or `valet install` ever again once the initial Valet+ installation is complete.
 


### PR DESCRIPTION
With php7.2, you solve the issue: PHP Startup: Unable to load dynamic library '/usr/local/opt/php71-pdo-pgsql/pdo_pgsql.so'.

Add an extra parameter to ping value, too.